### PR TITLE
Clean up studentcontacts

### DIFF
--- a/_data/studentcontacts.yml
+++ b/_data/studentcontacts.yml
@@ -1,145 +1,141 @@
-# Please add new emails to the end of this file.
-- group: School Captains
+- name: School Captains
+  members:
+    - position: School Captain
+      name: Jackson Long
+      email:
 
-- position: School Captain
-  name: Jackson Long
-  email: 
+    - position: School Vice-Captain
+      name: Oliver Johnson
+      email:
 
-- position: School Vice-Captain
-  name: Oliver Johnson
-  email: 
+    - position: Junior School Captain
+      name:
+      email:
 
-- position: Junior School Captain
-  name: 
-  email: 
+    - position: Junior School Captain
+      name:
+      email:
 
-- position: Junior School Captain
-  name: 
-  email: 
+    - position: Junior School Captain
+      name:
+      email:
 
-- position: Junior School Captain
-  name: 
-  email: 
+    - position: Junior School Captain
+      name:
+      email:
 
-- position: Junior School Captain
-  name: 
-  email: 
 
-- endgroupgroup: 
-- group: SRC Cabinet
+- name: SRC Cabinet
+  members:
+    - position: President
+      name: Yoann Colin
+      email:
 
-- position: President
-  name: Yoann Colin
-  email: 
+    - position: Vice-President
+      name: Ben Qin
+      email:
 
-- position: Vice-President
-  name: Ben Qin
-  email: 
+    - position: Secretary
+      name: Arman Riazati
+      email:
 
-- position: Secretary
-  name: Arman Riazati
-  email: 
+    - position: Assistant Secretary
+      name: Rivi Prathapasinghe
+      email:
 
-- position: Assistant Secretary
-  name: Rivi Prathapasinghe
-  email: 
+    - position: Treasurer
+      name: Victor Soong
+      email:
 
-- position: Treasurer
-  name: Victor Soong
-  email: 
+    - position: Assistant Treasurer
+      name: Rahul Sathish
+      email:
 
-- position: Assistant Treasurer
-  name: Rahul Sathish
-  email: 
 
-- endgroupgroup: 
-- group: House Captains
+- name: House Captains
+  members:
+    - position: Como Captain
+      name: Sothea-Roth Bak
+      email:
 
-- position: Como Captain
-  name: Sothea-Roth Bak
-  email: 
+    - position: Como Vice-Captain
+      name:
+      email:
 
-- position: Como Vice-Captain
-  name: 
-  email: 
+    - position: Forrest Captain
+      name: James Richter
+      email:
 
-- position: Forrest Captain
-  name: James Richter
-  email: 
+    - position: Forrest Vice-Captain
+      name: Zac Zhou
+      email:
 
-- position: Forrest Vice-Captain
-  name: Zac Zhou
-  email: 
+    - position: Waterloo Captain
+      name:
+      email:
 
-- position: Waterloo Captain
-  name: 
-  email: 
+    - position: Waterloo Vice-Captain
+      name:
+      email:
 
-- position: Waterloo Vice-Captain
-  name: 
-  email: 
+    - position: Yarra Captain
+      name:
+      email:
 
-- position: Yarra Captain
-  name: 
-  email: 
+    - position: Yarra Vice-Captain
+      name:
+      email:
 
-- position: Yarra Vice-Captain
-  name: 
-  email: 
+- name: SRC Executives
+  members:
+    - position: Year 12 Executive
+      name:
+      email:
 
-- endgroupgroup: 
-- group: SRC Executives
+    - position: Year 12 Executive
+      name:
+      email:
 
-- position: Year 12 Executive
-  name: 
-  email: 
+    - position: Year 11 Executive
+      name:
+      email:
 
-- position: Year 12 Executive
-  name: 
-  email: 
+    - position: Year 11 Executive
+      name:
+      email:
 
-- position: Year 11 Executive
-  name: 
-  email: 
+    - position: Year 10 Executive
+      name:
+      email:
 
-- position: Year 11 Executive
-  name: 
-  email: 
+    - position: Year 10 Executive
+      name:
+      email:
 
-- position: Year 10 Executive
-  name: 
-  email: 
+    - position: Year 9 Executive
+      name:
+      email:
 
-- position: Year 10 Executive
-  name: 
-  email: 
+    - position: Year 9 Executive
+      name:
+      email:
 
-- position: Year 9 Executive
-  name: 
-  email: 
+- name: IT Captains
+  members:
+    - position: IT Captain
+      name:
+      email:
 
-- position: Year 9 Executive
-  name: 
-  email: 
+    - position: IT Vice-Captain
+      name:
+      email:
 
-- endgroupgroup: 
-- group: IT Captains
+- name: Music Captains
+  members:
+    - position: Music Captain
+      name:
+      email:
 
-- position: IT Captain
-  name: 
-  email: 
-
-- position: IT Vice-Captain
-  name: 
-  email: 
-
-- endgroupgroup: 
-- group: Music Captains
-
-- position: Music Captain
-  name: 
-  email: 
-
-- position: Music Vice Captain
-  name: 
-  email: 
+    - position: Music Vice Captain
+      name:
+      email:

--- a/studentcontacts/index.html
+++ b/studentcontacts/index.html
@@ -5,30 +5,25 @@ title: Student Leader Contacts
 <div class="inner emails-body fade-in fade-two">
     <div><a class="pure-button button-xlarge button-red" href="../"> &larr; back</a></div>
     <h1>Student Leader Contacts</h1>
-    <div>Here you will find contact details for the student leaders. This page is still udner development.</div>
-    <br>
     <div class="small">
-        {% assign students = site.data.studentcontacts%}
-        {% for student in students %}
-        {% if student.group %}<b>{{student.group}}</b>
-        <br>
-        <table style="width:100%">
-            <tr>
-                <th>Position</th>
-                <th>Name</th>
-                <th>Email</th>
-            </tr>
-            {% endif %}
-            {% if student.position %}
-            <tr>
-                <td>{{student.position}}</td>
-                <td>{{student.name}}</td>
-                <td><a href="mailto:{{ student.email }}">{{ student.email }}</a></td>
-            </tr>
-            {% endif %}
-            {% if student.endgroup %}
-            </table><br>
-            {% endif %}
-            {% endfor %}
+        <table style="max-width: 400px; margin: 0 auto;">
+            <tbody>
+                {% assign groups = site.data.studentcontacts%}
+                {% for group in groups %}
+                <tr>
+                    <th colspan="3">
+                        {{group.name}}
+                    </th>
+                </tr>
+                {% for member in group.members %}
+                <tr>
+                    <td><i>{{ member.position }}</i></td>
+                    <td>{% if member.email %}<a href="mailto:{{ member.email }}">{% endif %}{{ member.name }}{% if member.email %}</a>{% endif %}</td>
+                </tr>
+                {% endfor %}
+                <tr><td>&nbsp;</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 </div>


### PR DESCRIPTION
When a member has an email their name turns into a link to the email. Should change this later to a copy-able link, but currently unsure of how to do so aesthetically.
