### PR TITLE
Changed Mail Setup to use iiNet's setup page

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -43,7 +43,7 @@
   colour: blue
 
 - name: Mail Setup
-  url: http://pdrew.me/MHS/mailprofile.html
+  url: https://webmail.netspace.net.au/?iosprofile
   size: 1-2
   colour: blue
 


### PR DESCRIPTION
iiNet created their own one-click provisioning profile generator, so I changed the Mail Setup button's link to use it.
