### PR TITLE
Fix 404 links

### DIFF
--- a/wifisetup/macos/index.html
+++ b/wifisetup/macos/index.html
@@ -4,24 +4,25 @@ title: Wi-Fi Software for macOS
 sections:
     - type: small
       body:
-      - title: Sophos Anti-Virus
+
+      - title: Company Portal
 
       - name: Install
-        url: http://software.mhs.vic.edu.au/sophosinstall.zip
+	url: https://go.microsoft.com/fwlink/?linkid=853070
 
       -
 
       - title: Aruba ClearPass
 
       - name: Install
-        url: http://software.mhs.vic.edu.au/ClearPassOnGuardInstall.dmg
+        url: http://itonlineservices.mhs.vic.edu.au/ClearPassOnGuardInstall.dmg
 
       -
 
       - title: Wi-Fi Certificate
 
       - name: Install
-        url: http://software.mhs.vic.edu.au/byodupdater.pkg
+        url: http://itonlineservices.mhs.vic.edu.au/MHSPalo.crt
 
 ---
 <h3>You need to install...</h3>

--- a/wifisetup/windows/index.html
+++ b/wifisetup/windows/index.html
@@ -4,24 +4,18 @@ title: Wi-Fi Software for Windows
 sections:
     - type: small
       body:
-      - title: Sophos Anti-Virus
-
-      - name: Install
-        url: http://software.mhs.vic.edu.au/sophosSetup.exe
-
-      -
 
       - title: Aruba ClearPass
 
       - name: Install
-        url: http://software.mhs.vic.edu.au/ClearPassOnGuardInstall.exe
+        url: http://itonlineservices.mhs.vic.edu.au/ClearPassOnGuardInstall.msi
 
       -
 
       - title: Wi-Fi Certificate
 
       - name: Install
-        url: http://software.mhs.vic.edu.au/BYODClient.exe
+        url: http://itonlineservices.mhs.vic.edu.au/MHSPalo.crt
 
 ---
 <h3>You need to install...</h3>


### PR DESCRIPTION
software.mhs.vic.edu.au no longer exists so I changed a few links to itonlineservices.mhs.vic.edu.au instead. Also, Sophos Antivirus was replaced with Microsoft InTune which I changed.